### PR TITLE
Make GitHub action deploy page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run Credo
         run: mix credo --strict
       - name: Dispatch CD workflow
-        if: github.event.pull_request.merged == true && github.ref == 'refs/heads/main'
+        if: github.event.pull_request.merged == true && contains('refs/heads/main', github.ref)
         uses: benc-uk/workflow-dispatch@v1
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

Improvement for #24 
Now CI launch CD if the ref is contained. so it doesn't matter if the ref has more information in it