### PR TITLE
Run CD when PR is merged

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,7 @@ jobs:
       uses: chetan/invalidate-cloudfront-action@v2
       env:
         PATHS: "/public"
-        AWS_REGION: 'us-east-1'
+        AWS_REGION: us-east-1
         DISTRIBUTION: ${{ secrets.DISTRIBUTION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: MintACoin CI
 
 on:
-  push:
-    branches:
-      - main
-      - develop
   pull_request:
+    types: [closed, review_requested, ready_for_review, synchronize, opened]
 
 jobs:
   tests:
@@ -48,7 +45,7 @@ jobs:
       - name: Run Credo
         run: mix credo --strict
       - name: Dispatch CD workflow
-        if: github.event.pull_request.merged == true && contains('refs/heads/main', github.ref)
+        if: github.event.pull_request.merged && contains('refs/heads/main', github.ref)
         uses: benc-uk/workflow-dispatch@v1
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

Fix in #24 
now It detects when the PR is merged. before, it launched CI after the push in main, but now it is run when the PR is closed, in that way we can detect if the PR was merged or not