### PR TITLE
Keypair and Mnemonic modules

### DIFF
--- a/apps/mintacoin/lib/mintacoin/encryption.ex
+++ b/apps/mintacoin/lib/mintacoin/encryption.ex
@@ -17,20 +17,7 @@ defmodule Mintacoin.Encryption do
   def decrypt(ciphertext, key), do: impl().decrypt(ciphertext, key)
 
   @impl true
-  def random_keypair, do: impl().random_keypair()
-
-  @impl true
-  def public_key_from_secret_key(secret_key), do: impl().public_key_from_secret_key(secret_key)
-
-  @impl true
   def one_time_token, do: impl().one_time_token()
-
-  @impl true
-  def mnemonic_encrypt(secret_key), do: impl().mnemonic_encrypt(secret_key)
-
-  @impl true
-  def recover_secret_key_from_seed_words(encrypted_secret, seed_words),
-    do: impl().recover_secret_key_from_seed_words(encrypted_secret, seed_words)
 
   @spec impl() :: atom()
   defp impl, do: Application.get_env(:encryption, :impl, Default)

--- a/apps/mintacoin/lib/mintacoin/encryption/default.ex
+++ b/apps/mintacoin/lib/mintacoin/encryption/default.ex
@@ -1,18 +1,14 @@
 defmodule Mintacoin.Encryption.Default do
-  @moduledoc false
+  @moduledoc """
+  This module provides a default implementation o for the Encryption
+  module using :crypto erlang's module.
+  """
 
   @behaviour Mintacoin.Encryption.Spec
 
-  @type public_key() :: String.t()
-  @type secret_key() :: String.t()
-  @type keypair() :: {public_key(), secret_key()}
-
   @block_size 16
   @cipher :aes_128_cbc
-  @language :english
   @hash_algorithm :sha256
-  @key_type :eddsa
-  @edwards_curve_ed :ed25519
 
   @impl true
   def generate_secret do
@@ -63,60 +59,6 @@ defmodule Mintacoin.Encryption.Default do
     end
   end
 
-  @impl true
-  def random_keypair do
-    @key_type
-    |> :crypto.generate_key(@edwards_curve_ed)
-    |> encode_keypair()
-  end
-
-  @impl true
-  def public_key_from_secret_key(secret_key) do
-    {:ok, secret_key} = Base.hex_decode32(secret_key, padding: false)
-
-    @key_type
-    |> :crypto.generate_key(@edwards_curve_ed, secret_key)
-    |> encode_keypair()
-  rescue
-    _error -> {:error, :decoding_error}
-  end
-
-  @impl true
-  def mnemonic_encrypt(secret_key_64) do
-    entropy = generate_secret()
-    words = Bip39.get_words(@language)
-
-    seed_words =
-      entropy
-      |> Base.decode64!(padding: false)
-      |> Bip39.entropy_to_mnemonic(words)
-
-    case encrypt(secret_key_64, entropy) do
-      {:ok, encrypted_secret} ->
-        {:ok, encrypted_secret, seed_words}
-
-      error ->
-        error
-    end
-  end
-
-  @impl true
-  def recover_secret_key_from_seed_words(encrypted_secret, seed_words) do
-    entropy =
-      @language
-      |> Bip39.get_words()
-      |> (&Bip39.mnemonic_to_entropy(seed_words, &1)).()
-      |> Base.encode64(padding: false)
-
-    case decrypt(encrypted_secret, entropy) do
-      {:ok, secret_key_64} ->
-        {:ok, secret_key_64}
-
-      error ->
-        error
-    end
-  end
-
   @spec unpad(data :: String.t()) :: String.t()
   defp unpad(data) do
     to_remove = :binary.last(data)
@@ -127,13 +69,5 @@ defmodule Mintacoin.Encryption.Default do
   defp pad(data, block_size) do
     to_add = block_size - rem(byte_size(data), block_size)
     data <> :binary.copy(<<to_add>>, to_add)
-  end
-
-  @spec encode_keypair(keypair :: keypair()) :: {:ok, keypair()}
-  defp encode_keypair({public_key, secret_key}) do
-    encoded_public_key = Base.hex_encode32(public_key, padding: false)
-    encoded_secret_key = Base.hex_encode32(secret_key, padding: false)
-
-    {:ok, {encoded_public_key, encoded_secret_key}}
   end
 end

--- a/apps/mintacoin/lib/mintacoin/encryption/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/encryption/spec.ex
@@ -6,12 +6,7 @@ defmodule Mintacoin.Encryption.Spec do
   @type secret() :: String.t()
   @type ciphertext() :: String.t()
   @type payload() :: String.t()
-  @type public_key() :: String.t()
-  @type secret_key() :: String.t()
   @type token() :: String.t()
-  @type encrypted_secret() :: String.t()
-  @type seed_words() :: list(String.t())
-  @type keypair() :: {public_key(), secret_key()}
   @type error() :: {:error, :decoding_error | :encryption_error}
 
   @callback generate_secret :: secret()
@@ -20,15 +15,5 @@ defmodule Mintacoin.Encryption.Spec do
 
   @callback decrypt(ciphertext(), secret()) :: {:ok, payload()} | error()
 
-  @callback random_keypair() :: {:ok, keypair()}
-
-  @callback public_key_from_secret_key(secret_key()) :: {:ok, keypair()} | error()
-
   @callback one_time_token() :: {:ok, token()}
-
-  @callback mnemonic_encrypt(secret_key()) ::
-              {:ok, {encrypted_secret(), seed_words()}} | error()
-
-  @callback recover_secret_key_from_seed_words(encrypted_secret(), seed_words()) ::
-              {:ok, encrypted_secret()} | error()
 end

--- a/apps/mintacoin/lib/mintacoin/encryption/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/encryption/spec.ex
@@ -3,17 +3,17 @@ defmodule Mintacoin.Encryption.Spec do
   Specifies the functions available for the Encryption
   """
 
-  @type secret() :: String.t()
-  @type ciphertext() :: String.t()
-  @type payload() :: String.t()
-  @type token() :: String.t()
-  @type error() :: :decoding_error | :encryption_error
+  @type secret :: String.t()
+  @type ciphertext :: String.t()
+  @type payload :: String.t()
+  @type token :: String.t()
+  @type error :: :decoding_error | :encryption_error
 
-  @callback generate_secret :: secret()
+  @callback generate_secret :: secret
 
-  @callback encrypt(payload(), secret()) :: {:ok, ciphertext()} | {:error, error()}
+  @callback encrypt(payload, secret) :: {:ok, ciphertext} | {:error, error}
 
-  @callback decrypt(ciphertext(), secret()) :: {:ok, payload()} | {:error, error()}
+  @callback decrypt(ciphertext, secret) :: {:ok, payload} | {:error, error}
 
-  @callback one_time_token() :: {:ok, token()}
+  @callback one_time_token :: {:ok, token}
 end

--- a/apps/mintacoin/lib/mintacoin/encryption/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/encryption/spec.ex
@@ -7,13 +7,13 @@ defmodule Mintacoin.Encryption.Spec do
   @type ciphertext() :: String.t()
   @type payload() :: String.t()
   @type token() :: String.t()
-  @type error() :: {:error, :decoding_error | :encryption_error}
+  @type error() :: :decoding_error | :encryption_error
 
   @callback generate_secret :: secret()
 
-  @callback encrypt(payload(), secret()) :: {:ok, ciphertext()} | error()
+  @callback encrypt(payload(), secret()) :: {:ok, ciphertext()} | {:error, error()}
 
-  @callback decrypt(ciphertext(), secret()) :: {:ok, payload()} | error()
+  @callback decrypt(ciphertext(), secret()) :: {:ok, payload()} | {:error, error()}
 
   @callback one_time_token() :: {:ok, token()}
 end

--- a/apps/mintacoin/lib/mintacoin/keypair.ex
+++ b/apps/mintacoin/lib/mintacoin/keypair.ex
@@ -1,0 +1,18 @@
+defmodule Mintacoin.Keypair do
+  @moduledoc """
+  This module provides the boundary for the Keypair's operations.
+  """
+
+  @behaviour Mintacoin.Keypair.Spec
+
+  alias Mintacoin.Keypair.Default
+
+  @impl true
+  def random, do: impl().random()
+
+  @impl true
+  def from_secret_key(secret_key), do: impl().from_secret_key(secret_key)
+
+  @spec impl() :: atom()
+  defp impl, do: Application.get_env(:keypair, :impl, Default)
+end

--- a/apps/mintacoin/lib/mintacoin/keypair/default.ex
+++ b/apps/mintacoin/lib/mintacoin/keypair/default.ex
@@ -22,7 +22,7 @@ defmodule Mintacoin.Keypair.Default do
 
   @impl true
   def from_secret_key(secret_key) do
-    {:ok, secret_key} = Base.hex_decode32(secret_key, padding: false)
+    {:ok, secret_key} = Base.decode64(secret_key, padding: false)
 
     @key_type
     |> :crypto.generate_key(@edwards_curve_ed, secret_key)
@@ -34,7 +34,7 @@ defmodule Mintacoin.Keypair.Default do
   @spec encode_keypair(keypair :: keypair()) :: {:ok, keypair()}
   defp encode_keypair({public_key, secret_key}) do
     encoded_public_key = Base.hex_encode32(public_key, padding: false)
-    encoded_secret_key = Base.hex_encode32(secret_key, padding: false)
+    encoded_secret_key = Base.encode64(secret_key, padding: false)
 
     {:ok, {encoded_public_key, encoded_secret_key}}
   end

--- a/apps/mintacoin/lib/mintacoin/keypair/default.ex
+++ b/apps/mintacoin/lib/mintacoin/keypair/default.ex
@@ -6,9 +6,9 @@ defmodule Mintacoin.Keypair.Default do
 
   @behaviour Mintacoin.Keypair.Spec
 
-  @type public_key() :: String.t()
-  @type secret_key() :: String.t()
-  @type keypair() :: {public_key(), secret_key()}
+  @type public_key :: String.t()
+  @type secret_key :: String.t()
+  @type keypair :: {public_key, secret_key}
 
   @key_type :eddsa
   @edwards_curve_ed :ed25519
@@ -31,7 +31,7 @@ defmodule Mintacoin.Keypair.Default do
     _error -> {:error, :secret_key_error}
   end
 
-  @spec encode_keypair(keypair :: keypair()) :: {:ok, keypair()}
+  @spec encode_keypair(keypair) :: {:ok, keypair}
   defp encode_keypair({public_key, secret_key}) do
     encoded_public_key = Base.hex_encode32(public_key, padding: false)
     encoded_secret_key = Base.encode64(secret_key, padding: false)

--- a/apps/mintacoin/lib/mintacoin/keypair/default.ex
+++ b/apps/mintacoin/lib/mintacoin/keypair/default.ex
@@ -1,0 +1,41 @@
+defmodule Mintacoin.Keypair.Default do
+  @moduledoc """
+  This module provides a default implementation o for the Keypair
+  module using :crypto erlang's module and generating ddsa keys.
+  """
+
+  @behaviour Mintacoin.Keypair.Spec
+
+  @type public_key() :: String.t()
+  @type secret_key() :: String.t()
+  @type keypair() :: {public_key(), secret_key()}
+
+  @key_type :eddsa
+  @edwards_curve_ed :ed25519
+
+  @impl true
+  def random do
+    @key_type
+    |> :crypto.generate_key(@edwards_curve_ed)
+    |> encode_keypair()
+  end
+
+  @impl true
+  def from_secret_key(secret_key) do
+    {:ok, secret_key} = Base.hex_decode32(secret_key, padding: false)
+
+    @key_type
+    |> :crypto.generate_key(@edwards_curve_ed, secret_key)
+    |> encode_keypair()
+  rescue
+    _error -> {:error, :decoding_error}
+  end
+
+  @spec encode_keypair(keypair :: keypair()) :: {:ok, keypair()}
+  defp encode_keypair({public_key, secret_key}) do
+    encoded_public_key = Base.hex_encode32(public_key, padding: false)
+    encoded_secret_key = Base.hex_encode32(secret_key, padding: false)
+
+    {:ok, {encoded_public_key, encoded_secret_key}}
+  end
+end

--- a/apps/mintacoin/lib/mintacoin/keypair/default.ex
+++ b/apps/mintacoin/lib/mintacoin/keypair/default.ex
@@ -28,7 +28,7 @@ defmodule Mintacoin.Keypair.Default do
     |> :crypto.generate_key(@edwards_curve_ed, secret_key)
     |> encode_keypair()
   rescue
-    _error -> {:error, :decoding_error}
+    _error -> {:error, :secret_key_error}
   end
 
   @spec encode_keypair(keypair :: keypair()) :: {:ok, keypair()}

--- a/apps/mintacoin/lib/mintacoin/keypair/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/keypair/spec.ex
@@ -6,9 +6,9 @@ defmodule Mintacoin.Keypair.Spec do
   @type public_key() :: String.t()
   @type secret_key() :: String.t()
   @type keypair() :: {public_key(), secret_key()}
-  @type error() :: {:error, :decoding_error | :encryption_error}
+  @type error() :: :secret_key_error
 
   @callback random() :: {:ok, keypair()}
 
-  @callback from_secret_key(secret_key()) :: {:ok, keypair()} | error()
+  @callback from_secret_key(secret_key()) :: {:ok, keypair()} | {:error, error()}
 end

--- a/apps/mintacoin/lib/mintacoin/keypair/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/keypair/spec.ex
@@ -1,0 +1,14 @@
+defmodule Mintacoin.Keypair.Spec do
+  @moduledoc """
+  Specifies the functions available for the Keypair module
+  """
+
+  @type public_key() :: String.t()
+  @type secret_key() :: String.t()
+  @type keypair() :: {public_key(), secret_key()}
+  @type error() :: {:error, :decoding_error | :encryption_error}
+
+  @callback random() :: {:ok, keypair()}
+
+  @callback from_secret_key(secret_key()) :: {:ok, keypair()} | error()
+end

--- a/apps/mintacoin/lib/mintacoin/keypair/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/keypair/spec.ex
@@ -3,12 +3,12 @@ defmodule Mintacoin.Keypair.Spec do
   Specifies the functions available for the Keypair module
   """
 
-  @type public_key() :: String.t()
-  @type secret_key() :: String.t()
-  @type keypair() :: {public_key(), secret_key()}
-  @type error() :: :secret_key_error
+  @type public_key :: String.t()
+  @type secret_key :: String.t()
+  @type keypair :: {public_key(), secret_key()}
+  @type error :: :secret_key_error
 
-  @callback random() :: {:ok, keypair()}
+  @callback random :: {:ok, keypair}
 
-  @callback from_secret_key(secret_key()) :: {:ok, keypair()} | {:error, error()}
+  @callback from_secret_key(secret_key()) :: {:ok, keypair} | {:error, error}
 end

--- a/apps/mintacoin/lib/mintacoin/mnemonic.ex
+++ b/apps/mintacoin/lib/mintacoin/mnemonic.ex
@@ -1,0 +1,21 @@
+defmodule Mintacoin.Mnemonic do
+  @moduledoc """
+  This module provides the boundary for the Mnemonic's operations.
+  """
+
+  @behaviour Mintacoin.Mnemonic.Spec
+
+  alias Mintacoin.Mnemonic.Default
+
+  @impl true
+  def random_entropy_and_mnemonic, do: impl().random_entropy_and_mnemonic()
+
+  @impl true
+  def to_entropy(seed_words), do: impl().to_entropy(seed_words)
+
+  @impl true
+  def from_entropy(entropy), do: impl().from_entropy(entropy)
+
+  @spec impl() :: atom()
+  defp impl, do: Application.get_env(:mnemonic, :impl, Default)
+end

--- a/apps/mintacoin/lib/mintacoin/mnemonic/default.ex
+++ b/apps/mintacoin/lib/mintacoin/mnemonic/default.ex
@@ -1,0 +1,45 @@
+defmodule Mintacoin.Mnemonic.Default do
+  @moduledoc """
+  This module provides a default implementation o for the Mnemonic
+  module using :crypto erlang's module and Bip39's dependency.1
+  """
+
+  @behaviour Mintacoin.Mnemonic.Spec
+
+  @block_size 16
+  @language :english
+
+  @impl true
+  def random_entropy_and_mnemonic do
+    raw_entropy = :crypto.strong_rand_bytes(@block_size)
+    entropy = Base.encode64(raw_entropy, padding: false)
+
+    @language
+    |> Bip39.get_words()
+    |> (&Bip39.entropy_to_mnemonic(raw_entropy, &1)).()
+    |> (&{:ok, {entropy, &1}}).()
+  end
+
+  @impl true
+  def to_entropy(seed_words) do
+    @language
+    |> Bip39.get_words()
+    |> (&Bip39.mnemonic_to_entropy(seed_words, &1)).()
+    |> Base.encode64(padding: false)
+    |> (&{:ok, &1}).()
+  rescue
+    _error -> {:error, :mnemonic_seed_words_error}
+  end
+
+  @impl true
+  def from_entropy(entropy) do
+    {:ok, raw_entropy} = Base.decode64(entropy, padding: false)
+
+    @language
+    |> Bip39.get_words()
+    |> (&Bip39.entropy_to_mnemonic(raw_entropy, &1)).()
+    |> (&{:ok, &1}).()
+  rescue
+    _error -> {:error, :mnemonic_entropy_error}
+  end
+end

--- a/apps/mintacoin/lib/mintacoin/mnemonic/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/mnemonic/spec.ex
@@ -1,0 +1,16 @@
+defmodule Mintacoin.Mnemonic.Spec do
+  @moduledoc """
+  Specifies the functions available for the Mnemonic
+  """
+
+  @type entropy() :: String.t()
+  @type seed_words() :: list(String.t())
+  @type error() ::
+          {:error, :decoding_error | :mnemonic_seed_words_error | :mnemonic_entropy_error}
+
+  @callback random_entropy_and_mnemonic() :: {:ok, {entropy(), seed_words()}}
+
+  @callback to_entropy(seed_words()) :: {:ok, entropy()} | error()
+
+  @callback from_entropy(entropy()) :: {:ok, seed_words()} | error()
+end

--- a/apps/mintacoin/lib/mintacoin/mnemonic/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/mnemonic/spec.ex
@@ -3,13 +3,13 @@ defmodule Mintacoin.Mnemonic.Spec do
   Specifies the functions available for the Mnemonic
   """
 
-  @type entropy() :: String.t()
-  @type seed_words() :: list(String.t())
-  @type error() :: :mnemonic_seed_words_error | :mnemonic_entropy_error
+  @type entropy :: String.t()
+  @type seed_words :: list(String.t())
+  @type error :: :mnemonic_seed_words_error | :mnemonic_entropy_error
 
-  @callback random_entropy_and_mnemonic() :: {:ok, {entropy(), seed_words()}}
+  @callback random_entropy_and_mnemonic :: {:ok, {entropy, seed_words}}
 
-  @callback to_entropy(seed_words()) :: {:ok, entropy()} | {:error, error()}
+  @callback to_entropy(seed_words) :: {:ok, entropy} | {:error, error}
 
-  @callback from_entropy(entropy()) :: {:ok, seed_words()} | {:error, error()}
+  @callback from_entropy(entropy) :: {:ok, seed_words} | {:error, error}
 end

--- a/apps/mintacoin/lib/mintacoin/mnemonic/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/mnemonic/spec.ex
@@ -5,12 +5,11 @@ defmodule Mintacoin.Mnemonic.Spec do
 
   @type entropy() :: String.t()
   @type seed_words() :: list(String.t())
-  @type error() ::
-          {:error, :decoding_error | :mnemonic_seed_words_error | :mnemonic_entropy_error}
+  @type error() :: :mnemonic_seed_words_error | :mnemonic_entropy_error
 
   @callback random_entropy_and_mnemonic() :: {:ok, {entropy(), seed_words()}}
 
-  @callback to_entropy(seed_words()) :: {:ok, entropy()} | error()
+  @callback to_entropy(seed_words()) :: {:ok, entropy()} | {:error, error()}
 
-  @callback from_entropy(entropy()) :: {:ok, seed_words()} | error()
+  @callback from_entropy(entropy()) :: {:ok, seed_words()} | {:error, error()}
 end

--- a/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
+++ b/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
@@ -1,6 +1,6 @@
 defmodule Mintacoin.Encryption.DefaultTest do
   @moduledoc """
-  This modules defines the test cases of the `Encryption` module.
+  This modules defines the test cases of the `Encryption.Default` module.
   """
 
   use Mintacoin.DataCase
@@ -65,46 +65,6 @@ defmodule Mintacoin.Encryption.DefaultTest do
 
     test "with invalid secret should return an error" do
       {:error, :decoding_error} = Encryption.decrypt("test", "invalid")
-    end
-  end
-
-  describe "random_keypair/0" do
-    test "should return a keypair with a public and secret key" do
-      {:ok, {public_key, secret_key}} = Encryption.random_keypair()
-      refute is_nil(public_key)
-      refute is_nil(secret_key)
-    end
-  end
-
-  describe "public_key_from_secret_key/1" do
-    test "with a valid secret key, it should return the keypair with the right public key", %{
-      public_key: pk,
-      secret_key: sk
-    } do
-      {:ok, {^pk, ^sk}} = Encryption.public_key_from_secret_key(sk)
-    end
-
-    test "with an invalid secret key, it should return an error" do
-      {:error, :decoding_error} = Encryption.public_key_from_secret_key("invalid")
-    end
-  end
-
-  describe "mnemonic_encrypt/1" do
-    test "should return the encrypted_secret and seed words", %{secret_key: sk} do
-      {:ok, encrypted_secret, seed_words} = Encryption.mnemonic_encrypt(sk)
-
-      refute is_nil(encrypted_secret)
-      12 = Enum.count(seed_words)
-    end
-  end
-
-  describe "recover_secret_key_from_seed_words/2" do
-    test "should return the secret key", %{
-      secret_key: sk,
-      encrypted_secret_key: encrypted_secret_key,
-      seed_words: seed_words
-    } do
-      {:ok, ^sk} = Encryption.recover_secret_key_from_seed_words(encrypted_secret_key, seed_words)
     end
   end
 end

--- a/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
+++ b/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
@@ -7,29 +7,6 @@ defmodule Mintacoin.Encryption.DefaultTest do
 
   alias Mintacoin.Encryption
 
-  setup do
-    %{
-      public_key: "PRI8EQ22VCOV30TGEOVPNAC5KODDO0UCJK0IKUF081DCS22MNU30",
-      secret_key: "CLC6HS1QP6OG6MMD2HKS5B53882KBMCUGT91VR7OS0KUGVEKSVM0",
-      encrypted_secret_key:
-        "GwSF3MyB7gR18R0Jwz3pw4H3drMIlH/j8lbarAA3eLrxholC4H6UUwTZJynbuvhWacg8J9Gzgu0jRbUKEy6lqILDmv+KlG8MiigwDGnPbuU",
-      seed_words: [
-        "skin",
-        "sudden",
-        "early",
-        "duty",
-        "dove",
-        "write",
-        "chuckle",
-        "stove",
-        "fossil",
-        "material",
-        "wire",
-        "stool"
-      ]
-    }
-  end
-
   describe "generate_secret/0" do
     test "should return a secret key" do
       secret = Encryption.generate_secret()

--- a/apps/mintacoin/test/mintacoin/encryption/encryption_test.exs
+++ b/apps/mintacoin/test/mintacoin/encryption/encryption_test.exs
@@ -22,32 +22,8 @@ defmodule Mintacoin.Encryption.CannedEncryptionImpl do
   end
 
   @impl true
-  def random_keypair do
-    send(self(), {:random_keypair, "KEYPAIR"})
-    :ok
-  end
-
-  @impl true
-  def public_key_from_secret_key(_secret_key) do
-    send(self(), {:public_key_from_secret_key, "KEYPAIR"})
-    :ok
-  end
-
-  @impl true
   def one_time_token do
     send(self(), {:one_time_token, "API_TOKEN"})
-    :ok
-  end
-
-  @impl true
-  def mnemonic_encrypt(_secret_key) do
-    send(self(), {:mnemonic_encrypt, "SEED_WORDS"})
-    :ok
-  end
-
-  @impl true
-  def recover_secret_key_from_seed_words(_encrypted_secret, _seed_words) do
-    send(self(), {:recover_secret_key_from_seed_words, "SECRET_KEY"})
     :ok
   end
 end
@@ -80,28 +56,8 @@ defmodule Mintacoin.EncryptionTest do
     assert_receive({:decrypt, "PLAIN_TEXT"})
   end
 
-  test "random_keypair/0" do
-    Mintacoin.Encryption.random_keypair()
-    assert_receive({:random_keypair, "KEYPAIR"})
-  end
-
-  test "public_key_from_secret_key/1" do
-    Mintacoin.Encryption.public_key_from_secret_key("PUBLIC_KEY")
-    assert_receive({:public_key_from_secret_key, "KEYPAIR"})
-  end
-
   test "one_time_token/0" do
     Mintacoin.Encryption.one_time_token()
     assert_receive({:one_time_token, "API_TOKEN"})
-  end
-
-  test "mnemonic_encrypt/1" do
-    Mintacoin.Encryption.mnemonic_encrypt("SECRET_KEY")
-    assert_receive({:mnemonic_encrypt, "SEED_WORDS"})
-  end
-
-  test "recover_secret_key_from_seed_words/2" do
-    Mintacoin.Encryption.recover_secret_key_from_seed_words("ENCRYPTED_SECRET", "SEED_WORDS")
-    assert_receive({:recover_secret_key_from_seed_words, "SECRET_KEY"})
   end
 end

--- a/apps/mintacoin/test/mintacoin/keypair/default_keypair_test.exs
+++ b/apps/mintacoin/test/mintacoin/keypair/default_keypair_test.exs
@@ -1,0 +1,37 @@
+defmodule Mintacoin.Keypair.DefaultTest do
+  @moduledoc """
+  This modules defines the test cases of the `Keypair` default module.
+  """
+
+  use Mintacoin.DataCase
+
+  alias Mintacoin.Keypair
+
+  setup do
+    %{
+      public_key: "PRI8EQ22VCOV30TGEOVPNAC5KODDO0UCJK0IKUF081DCS22MNU30",
+      secret_key: "CLC6HS1QP6OG6MMD2HKS5B53882KBMCUGT91VR7OS0KUGVEKSVM0"
+    }
+  end
+
+  describe "random/0" do
+    test "should return a keypair with a public and secret key" do
+      {:ok, {public_key, secret_key}} = Keypair.random()
+      refute is_nil(public_key)
+      refute is_nil(secret_key)
+    end
+  end
+
+  describe "from_secret_key/1" do
+    test "with a valid secret key, it should return the keypair with the right public key", %{
+      public_key: pk,
+      secret_key: sk
+    } do
+      {:ok, {^pk, ^sk}} = Keypair.from_secret_key(sk)
+    end
+
+    test "with an invalid secret key, it should return an error" do
+      {:error, :decoding_error} = Keypair.from_secret_key("invalid")
+    end
+  end
+end

--- a/apps/mintacoin/test/mintacoin/keypair/default_keypair_test.exs
+++ b/apps/mintacoin/test/mintacoin/keypair/default_keypair_test.exs
@@ -9,8 +9,8 @@ defmodule Mintacoin.Keypair.DefaultTest do
 
   setup do
     %{
-      public_key: "PRI8EQ22VCOV30TGEOVPNAC5KODDO0UCJK0IKUF081DCS22MNU30",
-      secret_key: "CLC6HS1QP6OG6MMD2HKS5B53882KBMCUGT91VR7OS0KUGVEKSVM0"
+      public_key: "30MGLHU1OGC23O06RFSHSA5325O49V05UEFA81FMN8JHV0AUVKG0",
+      secret_key: "0Qmk3ZinGhZLuIMJC2j/WNN+scV3MMLxkI5ALlAVun8"
     }
   end
 

--- a/apps/mintacoin/test/mintacoin/keypair/default_keypair_test.exs
+++ b/apps/mintacoin/test/mintacoin/keypair/default_keypair_test.exs
@@ -31,7 +31,7 @@ defmodule Mintacoin.Keypair.DefaultTest do
     end
 
     test "with an invalid secret key, it should return an error" do
-      {:error, :decoding_error} = Keypair.from_secret_key("invalid")
+      {:error, :secret_key_error} = Keypair.from_secret_key("invalid")
     end
   end
 end

--- a/apps/mintacoin/test/mintacoin/keypair/default_keypair_test.exs
+++ b/apps/mintacoin/test/mintacoin/keypair/default_keypair_test.exs
@@ -1,6 +1,6 @@
 defmodule Mintacoin.Keypair.DefaultTest do
   @moduledoc """
-  This modules defines the test cases of the `Keypair` default module.
+  This modules defines the test cases of the `Keypair.Default` default module.
   """
 
   use Mintacoin.DataCase

--- a/apps/mintacoin/test/mintacoin/keypair/keypair_test.exs
+++ b/apps/mintacoin/test/mintacoin/keypair/keypair_test.exs
@@ -1,0 +1,47 @@
+defmodule Mintacoin.Keypair.CannedKeypairImpl do
+  @moduledoc """
+  This modules defines the canned implementation for `Keypair`
+  """
+
+  @behaviour Mintacoin.Keypair.Spec
+
+  @impl true
+  def random do
+    send(self(), {:random, "KEYPAIR"})
+    :ok
+  end
+
+  @impl true
+  def from_secret_key(_secret_key) do
+    send(self(), {:from_secret_key, "KEYPAIR"})
+    :ok
+  end
+end
+
+defmodule Mintacoin.KeypairTest do
+  @moduledoc """
+  This modules defines the test cases of the `Keypair` abstraction module.
+  """
+
+  use ExUnit.Case
+
+  alias Mintacoin.Keypair.CannedKeypairImpl
+
+  setup do
+    Application.put_env(:keypair, :impl, CannedKeypairImpl)
+
+    on_exit(fn ->
+      Application.delete_env(:keypair, :impl)
+    end)
+  end
+
+  test "random/0" do
+    Mintacoin.Keypair.random()
+    assert_receive({:random, "KEYPAIR"})
+  end
+
+  test "from_secret_key/1" do
+    Mintacoin.Keypair.from_secret_key("PUBLIC_KEY")
+    assert_receive({:from_secret_key, "KEYPAIR"})
+  end
+end

--- a/apps/mintacoin/test/mintacoin/mnemonic/default_mnemonic_test.exs
+++ b/apps/mintacoin/test/mintacoin/mnemonic/default_mnemonic_test.exs
@@ -1,0 +1,64 @@
+defmodule Mintacoin.Mnemonic.DefaultTest do
+  @moduledoc """
+  This modules defines the test cases of the `Mnemonic.Default` module.
+  """
+
+  use Mintacoin.DataCase
+
+  alias Mintacoin.Mnemonic
+
+  setup do
+    %{
+      entropy: "cOyBaqug5GtdZ2rqMOAqdg",
+      seed_words: [
+        "ill",
+        "goat",
+        "follow",
+        "firm",
+        "atom",
+        "cup",
+        "intact",
+        "unhappy",
+        "tuition",
+        "mandate",
+        "appear",
+        "uncover"
+      ]
+    }
+  end
+
+  describe "random_entropy_and_mnemonic/0" do
+    test "returns a random set of entropy and seed words" do
+      {:ok, {entropy, seed_words}} = Mnemonic.random_entropy_and_mnemonic()
+
+      refute is_nil(entropy)
+      12 = Enum.count(seed_words)
+    end
+  end
+
+  describe "to_entropy/1" do
+    test "returns the pair entropy to the mnemonic", %{
+      entropy: spec_entropy,
+      seed_words: seed_words
+    } do
+      {:ok, ^spec_entropy} = Mnemonic.to_entropy(seed_words)
+    end
+
+    test "show error with invalid seed words" do
+      {:error, :mnemonic_seed_words_error} = Mnemonic.to_entropy("INVALID ENTRY")
+    end
+  end
+
+  describe "from_entropy/1" do
+    test "returns the mnemonic pair to the given entropy", %{
+      entropy: entropy,
+      seed_words: seed_words
+    } do
+      {:ok, ^seed_words} = Mnemonic.from_entropy(entropy)
+    end
+
+    test "show error with invalid entropy" do
+      {:error, :mnemonic_entropy_error} = Mnemonic.from_entropy("INVALID ENTRY")
+    end
+  end
+end

--- a/apps/mintacoin/test/mintacoin/mnemonic/mnemonic_test.exs
+++ b/apps/mintacoin/test/mintacoin/mnemonic/mnemonic_test.exs
@@ -1,0 +1,52 @@
+defmodule Mintacoin.Mnemonic.CannedMnemonicImpl do
+  @moduledoc false
+
+  @behaviour Mintacoin.Mnemonic.Spec
+
+  @impl true
+  def random_entropy_and_mnemonic do
+    send(self(), {:random_entropy_and_mnemonic, "ENTROPY_AND_SEED_WORDS"})
+    :ok
+  end
+
+  @impl true
+  def to_entropy(_seed_words) do
+    send(self(), {:to_entropy, "ENTROPY"})
+    :ok
+  end
+
+  @impl true
+  def from_entropy(_entropy) do
+    send(self(), {:from_entropy, "SEED_WORDS"})
+    :ok
+  end
+end
+
+defmodule Mintacoin.MnemonicTest do
+  use ExUnit.Case
+
+  alias Mintacoin.Mnemonic.CannedMnemonicImpl
+
+  setup do
+    Application.put_env(:mnemonic, :impl, CannedMnemonicImpl)
+
+    on_exit(fn ->
+      Application.delete_env(:mnemonic, :impl)
+    end)
+  end
+
+  test "random_entropy_and_mnemonic/0" do
+    Mintacoin.Mnemonic.random_entropy_and_mnemonic()
+    assert_receive({:random_entropy_and_mnemonic, "ENTROPY_AND_SEED_WORDS"})
+  end
+
+  test "to_entropy/1" do
+    Mintacoin.Mnemonic.to_entropy("SEED_WORDS")
+    assert_receive({:to_entropy, "ENTROPY"})
+  end
+
+  test "from_entropy/1" do
+    Mintacoin.Mnemonic.from_entropy("ENTROPY")
+    assert_receive({:from_entropy, "SEED_WORDS"})
+  end
+end


### PR DESCRIPTION
## Description
Removes functions related with Keypairs and Mnemonic phrases from the Encryption module and locates them in the corresponding module.

ℹ️ This PR closes #33

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes