### PR TITLE
Accounts schema and boundaries

### DIFF
--- a/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
@@ -1,0 +1,68 @@
+defmodule Mintacoin.Accounts do
+  @moduledoc """
+  This module is responsible for doing the CRUD operations for Accounts
+  """
+
+  alias Mintacoin.Repo
+  alias Ecto.Changeset
+  alias Mintacoin.Account
+
+  @type address :: String.t()
+  @type seed_words :: String.t()
+  @type secret_key :: String.t()
+  @type changes :: map()
+  @type parameter :: keyword()
+  @type error :: Changeset.t() | :not_found
+
+  @spec create(changes :: changes()) :: {:ok, Account.t()} | {:error, error()}
+  def create(changes) do
+    %Account{}
+    |> Account.create_changeset(changes)
+    |> Repo.insert()
+  end
+
+  @spec retrieve(address :: address()) :: {:ok, Account.t()} | nil
+  def retrieve(address) when is_binary(address) do
+    Repo.get_by(Account, address: address)
+  end
+
+  def retrieve(_address), do: {:error, :bad_argument}
+
+  @spec retrieve_by(parameter :: parameter()) :: {:ok, Account.t()} | nil
+  def retrieve_by(parameter) when is_list(parameter), do: Repo.get_by(Account, parameter)
+
+  def retrieve_by(_parameter), do: {:error, :bad_argument}
+
+  @spec update(address :: address(), changes :: changes()) ::
+          {:ok, Account.t()} | {:error, error()}
+  def update(address, changes) do
+    address
+    |> retrieve()
+    |> persist_changes(changes)
+  end
+
+  @spec delete(address :: address()) :: {:ok, Account.t()} | {:error, error()}
+  def delete(address) do
+    address
+    |> retrieve()
+    |> persist_changes(%{is_active: false})
+  end
+
+  @spec recover_secret_key(address :: address(), seed_words :: seed_words()) ::
+          {:ok, secret_key()}
+  def recover_secret_key(address, seed_words) do
+    address
+    |> retrieve()
+    |> Account.recover_secret_key(seed_words)
+  end
+
+  @spec persist_changes(account :: Account.t(), changes :: changes()) ::
+          {:ok, Account.t()} | {:error, error()}
+  defp persist_changes(%Account{} = account, changes) do
+    account
+    |> Account.changeset(changes)
+    |> Repo.update()
+  end
+
+  defp persist_changes(_account, _changes), do: {:error, :not_found}
+end

--- a/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
@@ -3,9 +3,8 @@ defmodule Mintacoin.Accounts do
   This module is responsible for doing the CRUD operations for Accounts
   """
 
-  alias Ecto.Changeset
+  alias Ecto.{Changeset, NoResultsError}
   alias Ecto.Query.CastError
-  alias Ecto.NoResultsError
   alias Mintacoin.{Repo, Account, Mnemonic, Encryption, Keypair}
 
   @type address :: String.t()

--- a/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
@@ -61,7 +61,7 @@ defmodule Mintacoin.Accounts do
   @spec recover_signature(address :: address(), seed_words :: seed_words()) ::
           {:ok, signature()} | {:error, error()}
   def recover_signature(address, seed_words) do
-    with {:ok, %{encrypted_signature: encrypted_signature}} <- retrieve(address),
+    with {:ok, %Account{encrypted_signature: encrypted_signature}} <- retrieve(address),
          {:ok, entropy} <- Mnemonic.to_entropy(seed_words) do
       Encryption.decrypt(encrypted_signature, entropy)
     else

--- a/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
@@ -30,14 +30,17 @@ defmodule Mintacoin.Accounts do
     retrieve_by(address: address, status: @active_status)
   end
 
-  def retrieve(_address), do: {:error, :bad_argument}
+  def retrieve(_address), do: {:error, :not_found}
 
   @spec retrieve_by(parameter :: parameter()) ::
           {:ok, Account.t() | nil} | {:error, error()}
   def retrieve_by(parameter) when is_list(parameter) do
-    {:ok, Repo.get_by(Account, parameter)}
+    case Repo.get_by(Account, parameter) do
+      nil -> {:error, :not_found}
+      account -> {:ok, account}
+    end
   rescue
-    CastError -> {:error, :bad_argument}
+    CastError -> {:error, :not_found}
   end
 
   def retrieve_by(_parameter), do: {:error, :bad_argument}

--- a/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/accounts.ex
@@ -3,33 +3,36 @@ defmodule Mintacoin.Accounts do
   This module is responsible for doing the CRUD operations for Accounts
   """
 
-  alias Mintacoin.Repo
   alias Ecto.Changeset
-  alias Mintacoin.Account
+  alias Mintacoin.{Repo, Account, Mnemonic, Encryption, Keypair}
 
   @type address :: String.t()
   @type seed_words :: String.t()
-  @type secret_key :: String.t()
+  @type signature :: String.t()
   @type changes :: map()
   @type parameter :: keyword()
-  @type error :: Changeset.t() | :not_found
+  @type error :: Changeset.t() | :not_found | :decoding_error | :bad_argument
+
+  @archived_status :archived
 
   @spec create(changes :: changes()) :: {:ok, Account.t()} | {:error, error()}
   def create(changes) do
-    %Account{}
-    |> Account.create_changeset(changes)
+    changes
+    |> add_signature_fields()
+    |> (&Account.create_changeset(%Account{}, &1)).()
     |> Repo.insert()
   end
 
-  @spec retrieve(address :: address()) :: {:ok, Account.t()} | nil
+  @spec retrieve(address :: address()) :: {:ok, Account.t() | nil} | {:error, error()}
   def retrieve(address) when is_binary(address) do
-    Repo.get_by(Account, address: address)
+    {:ok, Repo.get_by(Account, address: address)}
   end
 
   def retrieve(_address), do: {:error, :bad_argument}
 
-  @spec retrieve_by(parameter :: parameter()) :: {:ok, Account.t()} | nil
-  def retrieve_by(parameter) when is_list(parameter), do: Repo.get_by(Account, parameter)
+  @spec retrieve_by(parameter :: parameter()) ::
+          {:ok, Account.t() | nil} | {:error, error()}
+  def retrieve_by(parameter) when is_list(parameter), do: {:ok, Repo.get_by(Account, parameter)}
 
   def retrieve_by(_parameter), do: {:error, :bad_argument}
 
@@ -43,26 +46,41 @@ defmodule Mintacoin.Accounts do
 
   @spec delete(address :: address()) :: {:ok, Account.t()} | {:error, error()}
   def delete(address) do
-    address
-    |> retrieve()
-    |> persist_changes(%{is_active: false})
+    update(address, %{status: @archived_status})
   end
 
-  @spec recover_secret_key(address :: address(), seed_words :: seed_words()) ::
-          {:ok, secret_key()}
-  def recover_secret_key(address, seed_words) do
-    address
-    |> retrieve()
-    |> Account.recover_secret_key(seed_words)
+  @spec recover_signature(address :: address(), seed_words :: seed_words()) ::
+          {:ok, signature()} | {:error, error()}
+  def recover_signature(address, seed_words) do
+    with {:ok, %{encrypted_signature: encrypted_signature}} <- retrieve(address),
+         {:ok, entropy} <- Mnemonic.to_entropy(seed_words) do
+      Encryption.decrypt(encrypted_signature, entropy)
+    else
+      error -> error
+    end
   end
 
-  @spec persist_changes(account :: Account.t(), changes :: changes()) ::
+  @spec persist_changes({:ok, account :: Account.t() | nil}, changes :: changes()) ::
           {:ok, Account.t()} | {:error, error()}
-  defp persist_changes(%Account{} = account, changes) do
+  defp persist_changes({:ok, %Account{} = account}, changes) do
     account
     |> Account.changeset(changes)
     |> Repo.update()
   end
 
   defp persist_changes(_account, _changes), do: {:error, :not_found}
+
+  @spec add_signature_fields(changes :: changes()) :: changes()
+  defp add_signature_fields(changes) do
+    {:ok, {derived_key, signature}} = Keypair.random()
+    {:ok, {entropy, seed_words}} = Mnemonic.random_entropy_and_mnemonic()
+    {:ok, encrypted_signature} = Encryption.encrypt(signature, entropy)
+
+    Map.merge(changes, %{
+      derived_key: derived_key,
+      encrypted_signature: encrypted_signature,
+      seed_words: seed_words,
+      signature: signature
+    })
+  end
 end

--- a/apps/mintacoin/lib/mintacoin/accounts/schema.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/schema.ex
@@ -50,8 +50,8 @@ defmodule Mintacoin.Account do
       :name,
       :status
     ])
-    |> validate_required([:email, :name])
-    |> unique_constraint([:email])
+    |> validate_email()
+    |> validate_required([:name])
   end
 
   @spec create_changeset(account :: Account.t(), changes :: map()) :: Changeset.t()
@@ -67,10 +67,19 @@ defmodule Mintacoin.Account do
       :signature
     ])
     |> add_unique_address()
-    |> validate_required([:email, :name, :derived_key, :encrypted_signature])
-    |> unique_constraint([:email])
+    |> validate_email()
+    |> validate_required([:name, :derived_key, :encrypted_signature])
     |> unique_constraint([:address])
     |> unique_constraint([:encrypted_signature])
+  end
+
+  @spec validate_email(changeset :: Changeset.t()) :: Changeset.t()
+  defp validate_email(changeset) do
+    changeset
+    |> validate_required([:email])
+    |> validate_format(:email, ~r/^[^\s]+@[^\s]+$/, message: "must have the @ sign and no spaces")
+    |> validate_length(:email, max: 160)
+    |> unique_constraint(:email)
   end
 
   @spec add_unique_address(changeset :: Changeset.t()) :: Changeset.t()

--- a/apps/mintacoin/lib/mintacoin/accounts/schema.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/schema.ex
@@ -83,8 +83,5 @@ defmodule Mintacoin.Account do
   end
 
   @spec add_unique_address(changeset :: Changeset.t()) :: Changeset.t()
-  defp add_unique_address(changeset) do
-    UUID.generate()
-    |> (&put_change(changeset, :address, &1)).()
-  end
+  defp add_unique_address(changeset), do: put_change(changeset, :address, UUID.generate())
 end

--- a/apps/mintacoin/lib/mintacoin/accounts/schema.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/schema.ex
@@ -1,0 +1,104 @@
+defmodule Mintacoin.Account do
+  @moduledoc """
+  Ecto schema for Account
+  """
+
+  use Ecto.Schema
+
+  import Ecto.Changeset
+  import EctoEnum
+
+  alias Ecto.Changeset
+
+  @type payload :: String.t()
+  @type token :: String.t()
+  @type error :: :decoding_error | :encryption_error
+
+  defenum(Status, :status, [
+    :active,
+    :archived
+  ])
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "accounts" do
+    field(:email, :string)
+    field(:name, :string)
+    field(:address, :binary_id)
+    field(:derived_key, :string)
+    field(:encrypted_signature, :string)
+    field(:is_active, :boolean, default: true)
+
+    field(:secret_key, :string, virtual: true)
+    field(:seed_words, :string, virtual: true)
+
+    timestamps()
+  end
+
+  @spec changeset(account :: Account.t(), changes :: map()) :: Changeset.t()
+  def changeset(account, changes) do
+    account
+    |> cast(changes, [
+      :email,
+      :name,
+      :is_active
+    ])
+    |> unique_constraint([:email, :address, :encrypted_signature])
+  end
+
+  @spec create_changeset(account :: Account.t(), changes :: map()) :: Changeset.t()
+  def create_changeset(account, changes) do
+    account
+    |> cast(changes, [
+      :email,
+      :name,
+      :derived_key,
+      :encrypted_signature,
+      :is_active
+    ])
+    |> add_unique_address()
+    |> encrypt_account_keypair()
+    |> validate_required([:email, :name, :derived_key, :encrypted_signature])
+    |> unique_constraint([:email])
+    |> unique_constraint([:address])
+    |> unique_constraint([:encrypted_signature])
+  end
+
+  @spec recover_secret_key(account :: Account.t(), seed_words :: String.t()) ::
+          {:ok, payload()} | {:error, error()}
+  def recover_secret_key(%{encrypted_signature: encrypted_signature}, seed_words) do
+    {:ok, entropy} =
+      seed_words
+      |> String.split()
+      |> Mintacoin.Mnemonic.to_entropy()
+
+    Mintacoin.Encryption.decrypt(encrypted_signature, entropy)
+  end
+
+  def recover_secret_key(nil, _seed_words), do: {:error, :not_found}
+
+  @spec add_unique_address(changeset :: Changeset.t()) :: Changeset.t()
+  defp add_unique_address(changeset) do
+    address = Ecto.UUID.generate()
+
+    cast(changeset, %{address: address}, [:address])
+  end
+
+  @spec encrypt_account_keypair(changeset :: Changeset.t()) :: Changeset.t()
+  defp encrypt_account_keypair(changeset) do
+    {:ok, {pk, sk}} = Mintacoin.Keypair.random()
+    {:ok, {entropy, mnemonic}} = Mintacoin.Mnemonic.random_entropy_and_mnemonic()
+    seed_words = Enum.join(mnemonic, " ")
+    {:ok, encrypted_secret} = Mintacoin.Encryption.encrypt(sk, entropy)
+
+    cast(
+      changeset,
+      %{
+        derived_key: pk,
+        encrypted_signature: encrypted_secret,
+        seed_words: seed_words,
+        secret_key: sk
+      },
+      [:derived_key, :encrypted_signature, :seed_words, :secret_key]
+    )
+  end
+end

--- a/apps/mintacoin/lib/mintacoin/accounts/schema.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/schema.ex
@@ -50,6 +50,7 @@ defmodule Mintacoin.Account do
       :name,
       :status
     ])
+    |> validate_required([:email, :name])
     |> unique_constraint([:email])
   end
 

--- a/apps/mintacoin/lib/mintacoin/accounts/schema.ex
+++ b/apps/mintacoin/lib/mintacoin/accounts/schema.ex
@@ -9,10 +9,18 @@ defmodule Mintacoin.Account do
   import EctoEnum
 
   alias Ecto.Changeset
+  alias Ecto.UUID
 
-  @type payload :: String.t()
-  @type token :: String.t()
-  @type error :: :decoding_error | :encryption_error
+  @type status :: :active | :archived
+
+  @type t :: %__MODULE__{
+          email: String.t(),
+          name: String.t(),
+          address: UUID.t(),
+          derived_key: String.t(),
+          encrypted_signature: String.t(),
+          status: status()
+        }
 
   defenum(Status, :status, [
     :active,
@@ -26,9 +34,9 @@ defmodule Mintacoin.Account do
     field(:address, :binary_id)
     field(:derived_key, :string)
     field(:encrypted_signature, :string)
-    field(:is_active, :boolean, default: true)
+    field(:status, Status, default: :active)
 
-    field(:secret_key, :string, virtual: true)
+    field(:signature, :string, virtual: true)
     field(:seed_words, :string, virtual: true)
 
     timestamps()
@@ -40,9 +48,9 @@ defmodule Mintacoin.Account do
     |> cast(changes, [
       :email,
       :name,
-      :is_active
+      :status
     ])
-    |> unique_constraint([:email, :address, :encrypted_signature])
+    |> unique_constraint([:email])
   end
 
   @spec create_changeset(account :: Account.t(), changes :: map()) :: Changeset.t()
@@ -53,52 +61,20 @@ defmodule Mintacoin.Account do
       :name,
       :derived_key,
       :encrypted_signature,
-      :is_active
+      :status,
+      :seed_words,
+      :signature
     ])
     |> add_unique_address()
-    |> encrypt_account_keypair()
     |> validate_required([:email, :name, :derived_key, :encrypted_signature])
     |> unique_constraint([:email])
     |> unique_constraint([:address])
     |> unique_constraint([:encrypted_signature])
   end
 
-  @spec recover_secret_key(account :: Account.t(), seed_words :: String.t()) ::
-          {:ok, payload()} | {:error, error()}
-  def recover_secret_key(%{encrypted_signature: encrypted_signature}, seed_words) do
-    {:ok, entropy} =
-      seed_words
-      |> String.split()
-      |> Mintacoin.Mnemonic.to_entropy()
-
-    Mintacoin.Encryption.decrypt(encrypted_signature, entropy)
-  end
-
-  def recover_secret_key(nil, _seed_words), do: {:error, :not_found}
-
   @spec add_unique_address(changeset :: Changeset.t()) :: Changeset.t()
   defp add_unique_address(changeset) do
-    address = Ecto.UUID.generate()
-
-    cast(changeset, %{address: address}, [:address])
-  end
-
-  @spec encrypt_account_keypair(changeset :: Changeset.t()) :: Changeset.t()
-  defp encrypt_account_keypair(changeset) do
-    {:ok, {pk, sk}} = Mintacoin.Keypair.random()
-    {:ok, {entropy, mnemonic}} = Mintacoin.Mnemonic.random_entropy_and_mnemonic()
-    seed_words = Enum.join(mnemonic, " ")
-    {:ok, encrypted_secret} = Mintacoin.Encryption.encrypt(sk, entropy)
-
-    cast(
-      changeset,
-      %{
-        derived_key: pk,
-        encrypted_signature: encrypted_secret,
-        seed_words: seed_words,
-        secret_key: sk
-      },
-      [:derived_key, :encrypted_signature, :seed_words, :secret_key]
-    )
+    UUID.generate()
+    |> (&put_change(changeset, :address, &1)).()
   end
 end

--- a/apps/mintacoin/lib/mintacoin/mnemonic/default.ex
+++ b/apps/mintacoin/lib/mintacoin/mnemonic/default.ex
@@ -17,14 +17,17 @@ defmodule Mintacoin.Mnemonic.Default do
     @language
     |> Bip39.get_words()
     |> (&Bip39.entropy_to_mnemonic(raw_entropy, &1)).()
+    |> Enum.join(" ")
     |> (&{:ok, {entropy, &1}}).()
   end
 
   @impl true
   def to_entropy(seed_words) do
+    mnemonic_list = String.split(seed_words)
+
     @language
     |> Bip39.get_words()
-    |> (&Bip39.mnemonic_to_entropy(seed_words, &1)).()
+    |> (&Bip39.mnemonic_to_entropy(mnemonic_list, &1)).()
     |> Base.encode64(padding: false)
     |> (&{:ok, &1}).()
   rescue
@@ -38,6 +41,7 @@ defmodule Mintacoin.Mnemonic.Default do
     @language
     |> Bip39.get_words()
     |> (&Bip39.entropy_to_mnemonic(raw_entropy, &1)).()
+    |> Enum.join(" ")
     |> (&{:ok, &1}).()
   rescue
     _error -> {:error, :mnemonic_entropy_error}

--- a/apps/mintacoin/lib/mintacoin/mnemonic/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/mnemonic/spec.ex
@@ -4,7 +4,7 @@ defmodule Mintacoin.Mnemonic.Spec do
   """
 
   @type entropy :: String.t()
-  @type seed_words :: list(String.t())
+  @type seed_words :: String.t()
   @type error :: :mnemonic_seed_words_error | :mnemonic_entropy_error
 
   @callback random_entropy_and_mnemonic :: {:ok, {entropy(), seed_words()}}

--- a/apps/mintacoin/priv/repo/migrations/20220531214558_add_accounts_table.exs
+++ b/apps/mintacoin/priv/repo/migrations/20220531214558_add_accounts_table.exs
@@ -9,7 +9,7 @@ defmodule Mintacoin.Repo.Migrations.AddAccountsTable do
       add(:address, :uuid, unique: true)
       add(:derived_key, :string, null: false)
       add(:encrypted_signature, :string, null: false)
-      add(:is_active, :boolean)
+      add(:status, :string, null: false)
 
       timestamps()
     end

--- a/apps/mintacoin/priv/repo/migrations/20220531214558_add_accounts_table.exs
+++ b/apps/mintacoin/priv/repo/migrations/20220531214558_add_accounts_table.exs
@@ -1,0 +1,21 @@
+defmodule Mintacoin.Repo.Migrations.AddAccountsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:accounts, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
+      add(:email, :string, null: false, unique: true)
+      add(:name, :string)
+      add(:address, :uuid, unique: true)
+      add(:derived_key, :string, null: false)
+      add(:encrypted_signature, :string, null: false)
+      add(:is_active, :boolean)
+
+      timestamps()
+    end
+
+    create unique_index(:accounts, [:email])
+    create unique_index(:accounts, [:encrypted_signature])
+    create unique_index(:accounts, [:address])
+  end
+end

--- a/apps/mintacoin/test/mintacoin/accounts/accounts_test.exs
+++ b/apps/mintacoin/test/mintacoin/accounts/accounts_test.exs
@@ -54,16 +54,13 @@ defmodule Mintacoin.Accounts.AccountsTest do
       {:ok, %Account{address: address}} = Accounts.create(account_data)
       {:ok, %Account{address: ^address, status: :archived}} = Accounts.delete(address)
 
-      {:ok, nil} = Accounts.retrieve(address)
+      {:error, :not_found} = Accounts.retrieve(address)
     end
 
     test "with non existing address" do
-      {:ok, nil} = Accounts.retrieve("8dd3eaa3-c073-46f6-8e20-72c7f7203146")
-    end
-
-    test "with bad argument" do
-      {:error, :bad_argument} = Accounts.retrieve("INVALID_ADDRESS")
-      {:error, :bad_argument} = Accounts.retrieve(1)
+      {:error, :not_found} = Accounts.retrieve("8dd3eaa3-c073-46f6-8e20-72c7f7203146")
+      {:error, :not_found} = Accounts.retrieve("INVALID_ADDRESS")
+      {:error, :not_found} = Accounts.retrieve(1)
     end
   end
 
@@ -76,7 +73,7 @@ defmodule Mintacoin.Accounts.AccountsTest do
     end
 
     test "with non existing parameter" do
-      {:ok, nil} = Accounts.retrieve_by(email: "INVALID_EMAIL")
+      {:error, :not_found} = Accounts.retrieve_by(email: "INVALID_EMAIL")
     end
 
     test "with bad argument" do
@@ -116,11 +113,8 @@ defmodule Mintacoin.Accounts.AccountsTest do
 
     test "with non existing address" do
       {:error, :not_found} = Accounts.delete("8dd3eaa3-c073-46f6-8e20-72c7f7203146")
-    end
-
-    test "with bad argument" do
-      {:error, :bad_argument} = Accounts.delete("INVALID_ADDRESS")
-      {:error, :bad_argument} = Accounts.delete(1)
+      {:error, :not_found} = Accounts.delete("INVALID_ADDRESS")
+      {:error, :not_found} = Accounts.delete(1)
     end
   end
 

--- a/apps/mintacoin/test/mintacoin/accounts/accounts_test.exs
+++ b/apps/mintacoin/test/mintacoin/accounts/accounts_test.exs
@@ -103,6 +103,12 @@ defmodule Mintacoin.Accounts.AccountsTest do
       {:error, changeset} = Accounts.update(address, %{email: "account0@mail.com"})
       %{email: ["has already been taken"]} = errors_on(changeset)
     end
+
+    test "with wrong email format", %{account: account_data} do
+      {:ok, %Account{address: address}} = Accounts.create(account_data)
+      {:error, changeset} = Accounts.update(address, %{email: "INVALID_EMAIL"})
+      %{email: ["must have the @ sign and no spaces"]} = errors_on(changeset)
+    end
   end
 
   describe "delete/1" do

--- a/apps/mintacoin/test/mintacoin/accounts/accounts_test.exs
+++ b/apps/mintacoin/test/mintacoin/accounts/accounts_test.exs
@@ -1,0 +1,135 @@
+defmodule Mintacoin.Accounts.AccountsTest do
+  @moduledoc """
+    This module is used to group common tests for Accounts functions
+  """
+
+  use Mintacoin.DataCase, async: false
+
+  alias Mintacoin.{Account, Accounts}
+  alias Ecto.Adapters.SQL.Sandbox
+
+  setup do
+    :ok = Sandbox.checkout(Mintacoin.Repo)
+
+    %{
+      account: %{
+        email: "account@mail.com",
+        name: "Account name"
+      }
+    }
+  end
+
+  describe "create/1" do
+    test "with valid params", %{account: %{email: email, name: name} = account_data} do
+      {:ok, %Account{email: ^email, name: ^name} = account} = Accounts.create(account_data)
+      assert is_binary(account.id)
+      assert is_binary(account.address)
+      assert is_binary(account.derived_key)
+      assert is_binary(account.encrypted_signature)
+      assert is_binary(account.signature)
+      assert is_binary(account.seed_words)
+      :active = account.status
+    end
+
+    test "with invalid params" do
+      {:error, changeset} = Accounts.create(%{})
+      %{email: ["can't be blank"], name: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "with existing account", %{account: account_data} do
+      {:ok, _account} = Accounts.create(account_data)
+      {:error, changeset} = Accounts.create(account_data)
+
+      %{email: ["has already been taken"]} = errors_on(changeset)
+    end
+  end
+
+  describe "retrieve/1" do
+    test "with valid address", %{account: %{email: email, name: name} = account_data} do
+      {:ok, %Account{address: address}} = Accounts.create(account_data)
+      {:ok, %Account{email: ^email, name: ^name}} = Accounts.retrieve(address)
+    end
+
+    test "with archived account", %{account: account_data} do
+      {:ok, %Account{address: address}} = Accounts.create(account_data)
+      {:ok, %Account{address: ^address, status: :archived}} = Accounts.delete(address)
+
+      {:ok, nil} = Accounts.retrieve(address)
+    end
+
+    test "with non existing address" do
+      {:ok, nil} = Accounts.retrieve("8dd3eaa3-c073-46f6-8e20-72c7f7203146")
+    end
+
+    test "with bad argument" do
+      {:error, :bad_argument} = Accounts.retrieve("INVALID_ADDRESS")
+      {:error, :bad_argument} = Accounts.retrieve(1)
+    end
+  end
+
+  describe "retrieve_by/1" do
+    test "with valid parameter", %{account: %{email: email} = account_data} do
+      {:ok, %Account{id: id}} = Accounts.create(account_data)
+
+      {:ok, %Account{id: ^id, seed_words: nil, signature: nil}} =
+        Accounts.retrieve_by(email: email)
+    end
+
+    test "with non existing parameter" do
+      {:ok, nil} = Accounts.retrieve_by(email: "INVALID_EMAIL")
+    end
+
+    test "with bad argument" do
+      {:error, :bad_argument} = Accounts.retrieve_by(1)
+    end
+  end
+
+  describe "update/1" do
+    test "with valid params", %{account: account_data} do
+      {:ok, %Account{id: id, address: address}} = Accounts.create(account_data)
+
+      {:ok, %Account{id: ^id, address: ^address, name: "Another name"}} =
+        Accounts.update(address, %{name: "Another name"})
+    end
+
+    test "with blank required fields", %{account: account_data} do
+      {:ok, %Account{address: address}} = Accounts.create(account_data)
+      {:error, changeset} = Accounts.update(address, %{name: "", email: ""})
+      %{email: ["can't be blank"], name: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "with existing email", %{account: account_data} do
+      {:ok, %Account{address: address}} = Accounts.create(account_data)
+
+      {:ok, _account} = Accounts.create(%{email: "account0@mail.com", name: "Account 0"})
+
+      {:error, changeset} = Accounts.update(address, %{email: "account0@mail.com"})
+      %{email: ["has already been taken"]} = errors_on(changeset)
+    end
+  end
+
+  describe "delete/1" do
+    test "with valid address", %{account: account_data} do
+      {:ok, %Account{address: address, status: :active}} = Accounts.create(account_data)
+      {:ok, %Account{address: ^address, status: :archived}} = Accounts.delete(address)
+    end
+
+    test "with non existing address" do
+      {:error, :not_found} = Accounts.delete("8dd3eaa3-c073-46f6-8e20-72c7f7203146")
+    end
+
+    test "with bad argument" do
+      {:error, :bad_argument} = Accounts.delete("INVALID_ADDRESS")
+      {:error, :bad_argument} = Accounts.delete(1)
+    end
+  end
+
+  describe "recover_signature/2" do
+    test "should return signature", %{account: account_data} do
+      {:ok, %Account{address: address, seed_words: seed_words, signature: signature}} =
+        Accounts.create(account_data)
+
+      {:ok, ^signature} = Accounts.recover_signature(address, seed_words)
+    end
+  end
+end

--- a/apps/mintacoin/test/mintacoin/mnemonic/default_mnemonic_test.exs
+++ b/apps/mintacoin/test/mintacoin/mnemonic/default_mnemonic_test.exs
@@ -10,20 +10,7 @@ defmodule Mintacoin.Mnemonic.DefaultTest do
   setup do
     %{
       entropy: "cOyBaqug5GtdZ2rqMOAqdg",
-      seed_words: [
-        "ill",
-        "goat",
-        "follow",
-        "firm",
-        "atom",
-        "cup",
-        "intact",
-        "unhappy",
-        "tuition",
-        "mandate",
-        "appear",
-        "uncover"
-      ]
+      seed_words: "ill goat follow firm atom cup intact unhappy tuition mandate appear uncover"
     }
   end
 
@@ -32,7 +19,11 @@ defmodule Mintacoin.Mnemonic.DefaultTest do
       {:ok, {entropy, seed_words}} = Mnemonic.random_entropy_and_mnemonic()
 
       refute is_nil(entropy)
-      12 = Enum.count(seed_words)
+
+      12 =
+        seed_words
+        |> String.split()
+        |> Enum.count()
     end
   end
 

--- a/apps/mintacoin/test/support/accounts/accounts_factory.ex
+++ b/apps/mintacoin/test/support/accounts/accounts_factory.ex
@@ -1,0 +1,59 @@
+defmodule Mintacoin.AccountFactory do
+  @moduledoc """
+  Allow the creation of accounts while testing.
+  """
+
+  alias Mintacoin.Account
+  alias Ecto.UUID
+
+  defmacro __using__(_opts) do
+    quote do
+      @spec account_factory(attrs :: map()) :: Account.t()
+      def account_factory(attrs) do
+        email = Map.get(attrs, :email, sequence(:email, &"account#{&1}@example.com"))
+        name = Map.get(attrs, :name, sequence(:name, &"Account #{&1}"))
+        address = Map.get(attrs, :address, UUID.generate())
+        derived_key = Map.get(attrs, :derived_key, sequence(:derived_key, &"derived_key#{&1}"))
+
+        encrypted_signature =
+          Map.get(
+            attrs,
+            :encrypted_signature,
+            sequence(:encrypted_signature, &"encrypted_signature#{&1}")
+          )
+
+        signature =
+          Map.get(
+            attrs,
+            :signature,
+            sequence(:signature, &"signature#{&1}")
+          )
+
+        seed_words =
+          Map.get(
+            attrs,
+            :seed_words,
+            sequence(:seed_words, &"word#{&1} ")
+            |> String.duplicate(12)
+            |> String.trim_trailing()
+          )
+
+        status = Map.get(attrs, :status, :active)
+
+        %Account{
+          id: UUID.generate(),
+          email: email,
+          name: name,
+          address: address,
+          derived_key: derived_key,
+          encrypted_signature: encrypted_signature,
+          status: status,
+          signature: signature,
+          seed_words: seed_words
+        }
+        |> merge_attributes(attrs)
+        |> evaluate_lazy_attributes()
+      end
+    end
+  end
+end

--- a/apps/mintacoin/test/support/factory.ex
+++ b/apps/mintacoin/test/support/factory.ex
@@ -4,5 +4,8 @@ defmodule Mintacoin.Factory do
   """
   use ExMachina.Ecto, repo: Mintacoin.Repo
 
-  use Mintacoin.MinterFactory
+  use Mintacoin.{
+    MinterFactory,
+    AccountFactory
+  }
 end


### PR DESCRIPTION
## Description

Thi PR creates the Accounts' schema and boundaries based on the accounts as the entity representing a user in the system. 

### Accounts Functions
- `create/1`
- `retrieve/1`
- `update/1`
- `delete/1`
- `recover_secret_key/2`

ℹ️ This PR closes #26

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
