### PR TITLE
Handle multiple ciphers in the Encryption default module

### DIFF
--- a/apps/mintacoin/lib/mintacoin/encryption.ex
+++ b/apps/mintacoin/lib/mintacoin/encryption.ex
@@ -8,7 +8,7 @@ defmodule Mintacoin.Encryption do
   alias Mintacoin.Encryption.Default
 
   @impl true
-  def generate_secret, do: impl().generate_secret()
+  def generate_secret(opts \\ []), do: impl().generate_secret(opts)
 
   @impl true
   def encrypt(payload, key), do: impl().encrypt(payload, key)
@@ -17,7 +17,7 @@ defmodule Mintacoin.Encryption do
   def decrypt(ciphertext, key), do: impl().decrypt(ciphertext, key)
 
   @impl true
-  def one_time_token, do: impl().one_time_token()
+  def one_time_token(opts \\ []), do: impl().one_time_token(opts)
 
   @spec impl() :: atom()
   defp impl, do: Application.get_env(:encryption, :impl, Default)

--- a/apps/mintacoin/lib/mintacoin/encryption/default.ex
+++ b/apps/mintacoin/lib/mintacoin/encryption/default.ex
@@ -6,21 +6,21 @@ defmodule Mintacoin.Encryption.Default do
 
   @behaviour Mintacoin.Encryption.Spec
 
-  @token_size 16
+  @default_bytes_size 16
   @hash_algorithm :sha256
 
-  @default_block_size 32
-
   @impl true
-  def generate_secret do
-    @default_block_size
+  def generate_secret(opts \\ []) do
+    opts
+    |> Keyword.get(:bytes, @default_bytes_size)
     |> :crypto.strong_rand_bytes()
     |> Base.encode64(padding: false)
   end
 
   @impl true
-  def one_time_token do
-    @token_size
+  def one_time_token(opts \\ []) do
+    opts
+    |> Keyword.get(:bytes, @default_bytes_size)
     |> :crypto.strong_rand_bytes()
     |> (&:crypto.hash(@hash_algorithm, &1)).()
     |> Base.encode64(padding: false)

--- a/apps/mintacoin/lib/mintacoin/encryption/spec.ex
+++ b/apps/mintacoin/lib/mintacoin/encryption/spec.ex
@@ -7,13 +7,14 @@ defmodule Mintacoin.Encryption.Spec do
   @type ciphertext :: String.t()
   @type payload :: String.t()
   @type token :: String.t()
+  @type opts :: Keyword.t()
   @type error :: :decoding_error | :encryption_error
 
-  @callback generate_secret :: secret
+  @callback generate_secret(opts()) :: secret
 
   @callback encrypt(payload(), secret()) :: {:ok, ciphertext()} | {:error, error()}
 
   @callback decrypt(ciphertext(), secret()) :: {:ok, payload()} | {:error, error()}
 
-  @callback one_time_token :: {:ok, token()}
+  @callback one_time_token(opts()) :: {:ok, token()}
 end

--- a/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
+++ b/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
@@ -11,7 +11,7 @@ defmodule Mintacoin.Encryption.DefaultTest do
     test "should return a secret" do
       secret = Encryption.generate_secret()
       refute is_nil(secret)
-      32 = byte_size(Base.decode64!(secret, padding: false))
+      16 = byte_size(Base.decode64!(secret, padding: false))
     end
   end
 
@@ -24,16 +24,12 @@ defmodule Mintacoin.Encryption.DefaultTest do
 
   describe "encrypt/2" do
     test "with valid secret of 32 bytes should return a ciphertext" do
-      secret = Encryption.generate_secret()
+      secret = Encryption.generate_secret(bytes: 32)
       {:ok, _ciphertext} = Encryption.encrypt("test", secret)
     end
 
     test "with valid secret of 16 bytes should return a ciphertext" do
-      secret =
-        16
-        |> :crypto.strong_rand_bytes()
-        |> Base.encode64(padding: false)
-
+      secret = Encryption.generate_secret()
       {:ok, _ciphertext} = Encryption.encrypt("test", secret)
     end
 

--- a/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
+++ b/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
@@ -23,8 +23,17 @@ defmodule Mintacoin.Encryption.DefaultTest do
   end
 
   describe "encrypt/2" do
-    test "with valid secret should return a ciphertext" do
+    test "with valid secret of 32 bytes should return a ciphertext" do
       secret = Encryption.generate_secret()
+      {:ok, _ciphertext} = Encryption.encrypt("test", secret)
+    end
+
+    test "with valid secret of 16 bytes should return a ciphertext" do
+      secret =
+        16
+        |> :crypto.strong_rand_bytes()
+        |> Base.encode64(padding: false)
+
       {:ok, _ciphertext} = Encryption.encrypt("test", secret)
     end
 

--- a/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
+++ b/apps/mintacoin/test/mintacoin/encryption/default_encryption_test.exs
@@ -8,10 +8,10 @@ defmodule Mintacoin.Encryption.DefaultTest do
   alias Mintacoin.Encryption
 
   describe "generate_secret/0" do
-    test "should return a secret key" do
+    test "should return a secret" do
       secret = Encryption.generate_secret()
       refute is_nil(secret)
-      16 = byte_size(Base.decode64!(secret, padding: false))
+      32 = byte_size(Base.decode64!(secret, padding: false))
     end
   end
 

--- a/apps/mintacoin/test/mintacoin/encryption/encryption_test.exs
+++ b/apps/mintacoin/test/mintacoin/encryption/encryption_test.exs
@@ -4,7 +4,7 @@ defmodule Mintacoin.Encryption.CannedEncryptionImpl do
   @behaviour Mintacoin.Encryption.Spec
 
   @impl true
-  def generate_secret do
+  def generate_secret(_opts) do
     send(self(), {:generate_secret, "SECRET"})
     :ok
   end
@@ -22,7 +22,7 @@ defmodule Mintacoin.Encryption.CannedEncryptionImpl do
   end
 
   @impl true
-  def one_time_token do
+  def one_time_token(_opts) do
     send(self(), {:one_time_token, "API_TOKEN"})
     :ok
   end


### PR DESCRIPTION
## Description

This PR adds the feature to handle multiple ciphers in the Encryption default module.
The ciphers available depend on the byte size of the `secret`, see the table:

| secret's byte size | cipher |
| ----------------------- | -------- |
| 16                        | aes_128_cbc |
| 32                        | aes_256_cbc |


Related to #25, see https://github.com/kommitters/mintacoin/issues/25#issuecomment-1142712790

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
