### PR TITLE
Add Authenticate plug

### DIFF
--- a/apps/mintacoin_web/lib/mintacoin_web/plugs/authenticate.ex
+++ b/apps/mintacoin_web/lib/mintacoin_web/plugs/authenticate.ex
@@ -1,0 +1,39 @@
+defmodule MintacoinWeb.Plugs.Authenticate do
+  @moduledoc """
+  Validate authorization token in request header.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn, only: [halt: 1, put_status: 2, get_req_header: 2]
+  import Phoenix.Controller, only: [put_view: 2, render: 2]
+
+  alias MintacoinWeb.ErrorView
+  alias Mintacoin.Minters
+
+  @auth_header "authorization"
+
+  @type conn :: Plug.Conn.t()
+
+  @impl true
+  def init(default), do: default
+
+  @impl true
+  def call(conn, _default) do
+    with ["Bearer " <> api_key] <- get_req_header(conn, @auth_header),
+         true <- Minters.is_authorized?(api_key) do
+      conn
+    else
+      _error -> unauthorized_response(conn)
+    end
+  end
+
+  @spec unauthorized_response(conn :: conn()) :: conn()
+  defp unauthorized_response(conn) do
+    conn
+    |> put_status(:unauthorized)
+    |> put_view(ErrorView)
+    |> render(:"401")
+    |> halt()
+  end
+end

--- a/apps/mintacoin_web/lib/mintacoin_web/router.ex
+++ b/apps/mintacoin_web/lib/mintacoin_web/router.ex
@@ -5,8 +5,12 @@ defmodule MintacoinWeb.Router do
     plug :accepts, ["json"]
   end
 
-  scope "/api", MintacoinWeb do
-    pipe_through :api
+  pipeline :authenticated do
+    plug MintacoinWeb.Plugs.Authenticate
+  end
+
+  scope "/v1/", MintacoinWeb do
+    pipe_through [:api, :authenticated]
   end
 
   # Enables LiveDashboard only for development

--- a/apps/mintacoin_web/test/mintacoin_web/plugs/authenticate_test.exs
+++ b/apps/mintacoin_web/test/mintacoin_web/plugs/authenticate_test.exs
@@ -1,0 +1,40 @@
+defmodule MintacoinWeb.Plugs.AuthenticateTest do
+  @moduledoc """
+    This module is used to group common tests for the Authenticate Plug module.
+  """
+  use MintacoinWeb.ConnCase
+
+  import Phoenix.Controller, only: [put_format: 2]
+  import Plug.Conn, only: [put_req_header: 3]
+  import Mintacoin.Factory
+
+  alias MintacoinWeb.Plugs.Authenticate
+  alias Plug.Conn
+
+  @auth_header "authorization"
+  @api_key "6aRONqGFFpHq7xDgEvlbDnJURLzdjv/uMeHYQce3KQE"
+
+  setup do
+    insert(:minter, api_key: @api_key)
+    :ok
+  end
+
+  test "ensures that connection successfully passed through the plug", %{conn: conn} do
+    conn =
+      conn
+      |> put_format("json")
+      |> put_req_header(@auth_header, "Bearer #{@api_key}")
+      |> Authenticate.call(%{})
+
+    %Conn{state: :unset, status: nil} = conn
+  end
+
+  test "returns unauthorized response", %{conn: conn} do
+    conn =
+      conn
+      |> put_format("json")
+      |> Authenticate.call(%{})
+
+    assert response(conn, 401)
+  end
+end


### PR DESCRIPTION
## Description

This PR adds a plug called `Authenticate` which will ensure that the API key is provided in the requests' headers.

Fixes #52 



## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
